### PR TITLE
feat: handle configure

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 This is a simple __proof of concept__ based on [Clappr ad skeleton plugin](https://github.com/kslimani/clappr-html5-preroll-skeleton-plugin) example.
 
-This plugin is supported __ONLY__ by Clappr version `0.2.66` or greater. (_For older Clappr versions, use the `0.0.7` version of the plugin_).
+This plugin is supported __ONLY__ by Clappr version `0.2.87` or greater. (_For older Clappr versions, use the `0.0.7` or `0.1.0` version of the plugin_).
 
 On mobile devices, it support only [Clappr playbacks](https://github.com/clappr/clappr/tree/master/src/playbacks) which use an HTML5 video element.
 
@@ -26,17 +26,17 @@ Then just add `ClapprGoogleImaHtml5PrerollPlugin` into the list of plugins of yo
 ```javascript
 var player = new Clappr.Player({
   source: "http://your.video/here.mp4",
-  autoPlay: false, // Mandatory player option
+  autoPlay: false, // Set to false and use plugin autostart option (or set to true if tag is false)
   plugins: {
     core: [ClapprGoogleImaHtml5PrerollPlugin],
   },
   googleImaHtml5PrerollPlugin: {
-    tag: 'VAST_TAG_URL',
+    tag: 'VAST_TAG_URL', // VAST tag URL (or false to disable plugin)
     vpaid: 1, // Default is 0 (0 is DISABLED, 1 is ENABLED and 2 is INSECURE)
     // autostart: false, // Default is true
     // events: { /* Event map */ },
     // imaLoadTimeout: 3000, // Default is 6000 milliseconds
-    // nonLinearDuration: 10000, // Default is 5000 milliseconds
+    // nonLinearDuration: 20000, // Default is 15000 milliseconds
   }
 });
 ```

--- a/public/index.html
+++ b/public/index.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <meta name="viewport" content="width=655, user-scalable=yes" />
+    <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/can-autoplay@3.0.0/build/can-autoplay.min.js"></script>
     <!-- <script src="http://192.168.1.113:8080/console.js"></script> -->
     <!-- <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/clappr@0.2.87/dist/clappr.min.js"></script> -->
     <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/clappr@latest/dist/clappr.min.js"></script>
@@ -24,7 +25,7 @@
     <script>
       (function () {
         var $ = Clappr.$;
-        var isMobile = Clappr.Browser.isMobile || Clappr.Browser.isSafari;
+        // console.log('Clappr version ' + Clappr.version);
         // Clappr.Log.setLevel(0)
 
         // Sintel trailer - (c) copyright Blender Foundation - www.sintel.org
@@ -89,24 +90,35 @@
           p.style.height = h;
         };
 
-        var player = new Clappr.Player({
-          parentId: ".player",
-          source: SINTEL,
-          disableKeyboardShortcuts: true,
-          disableVideoTagContextMenu: true,
-          autoSeekFromUrl: false,
-          width: '100%',
-          height: '100%',
-          autoPlay: false,
-          playback: {
-            playInline: true,
-            recycleVideo: isMobile,
-          },
-          plugins: {
-            core: [ClapprGoogleImaHtml5PrerollPlugin],
-          },
-          googleImaHtml5PrerollPlugin: pluginConfig(vastTag, !isMobile),
-        })
+        var buildPlayer = function(source, autoPlay) {
+          return new Clappr.Player({
+            parentId: ".player",
+            source: source,
+            disableKeyboardShortcuts: true,
+            disableVideoTagContextMenu: true,
+            autoSeekFromUrl: false,
+            width: '100%',
+            height: '100%',
+            autoPlay: false, // will use plugin autostart
+            playback: {
+              playInline: true,
+              recycleVideo: Clappr.Browser.isMobile,
+            },
+            plugins: {
+              core: [ClapprGoogleImaHtml5PrerollPlugin],
+            },
+            googleImaHtml5PrerollPlugin: pluginConfig(vastTag, autoPlay),
+          });
+        };
+
+        var player;
+
+        // Handle browser autoplay policy
+        canAutoplay.video({timeout: 800, muted: false}).then(function(o) {
+          var ap = o.result === true;
+          // console.log('autoplay', ap);
+          player = buildPlayer(SINTEL, ap);
+        });
 
         $('.btn-resize').on('click', function() {
           resizePlayerDiv('1280px', '720px');

--- a/public/index.html
+++ b/public/index.html
@@ -2,7 +2,8 @@
 <html>
   <head>
     <meta name="viewport" content="width=655, user-scalable=yes" />
-    <!-- <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/clappr@0.2.80/dist/clappr.min.js"></script> -->
+    <!-- <script src="http://192.168.1.113:8080/console.js"></script> -->
+    <!-- <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/clappr@0.2.87/dist/clappr.min.js"></script> -->
     <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/clappr@latest/dist/clappr.min.js"></script>
     <script type="text/javascript" src="clappr-google-ima-html5-preroll-plugin.js"></script>
     <style>
@@ -15,51 +16,44 @@
   </head>
   <body>
     <div class="player"></div>
+    <button class="btn-resize">Resize player</button>
+    <button class="btn-reset">Reset player size</button>
+    <button class="btn-bunny">Bunny with ad</button>
+    <button class="btn-sintel">Sintel with ad</button>
+    <button class="btn-sintel-noad">Sintel without ad</button>
     <script>
       (function () {
+        var $ = Clappr.$;
+        var isMobile = Clappr.Browser.isMobile || Clappr.Browser.isSafari;
         // Clappr.Log.setLevel(0)
 
         // Sintel trailer - (c) copyright Blender Foundation - www.sintel.org
-        var videoUrl = 'https://static.playmedia-cdn.net/resources/sample/h264_sintel_trailer-1080p.mp4'
+        var SINTEL = 'https://static.playmedia-cdn.net/resources/sample/h264_sintel_trailer-1080p.mp4';
 
         // Big Buck Bunny - (c) copyright 2008, Blender Foundation - www.bigbuckbunny.org
-        // var videoUrl = 'http://www.streambox.fr/playlists/x36xhzz/x36xhzz.m3u8'
+        var BUNNY = 'http://www.streambox.fr/playlists/x36xhzz/x36xhzz.m3u8';
 
         // Single Inline Linear. See https://developers.google.com/interactive-media-ads/docs/sdks/html5/tags
-        var vastTag = 'https://pubads.g.doubleclick.net/gampad/ads?sz=640x480&iu=/124319096/external/single_ad_samples&ciu_szs=300x250&impl=s&gdfp_req=1&env=vp&output=vast&unviewed_position_start=1&cust_params=deployment%3Ddevsite%26sample_ct%3Dlinear&correlator='
+        var vastTag = 'https://pubads.g.doubleclick.net/gampad/ads?sz=640x480&iu=/124319096/external/single_ad_samples&ciu_szs=300x250&impl=s&gdfp_req=1&env=vp&output=vast&unviewed_position_start=1&cust_params=deployment%3Ddevsite%26sample_ct%3Dlinear&correlator=';
 
         // Single Skippable Inline
-        // var vastTag = 'https://pubads.g.doubleclick.net/gampad/ads?sz=640x480&iu=/124319096/external/single_ad_samples&ciu_szs=300x250&impl=s&gdfp_req=1&env=vp&output=vast&unviewed_position_start=1&cust_params=deployment%3Ddevsite%26sample_ct%3Dskippablelinear&correlator='
+        // var vastTag = 'https://pubads.g.doubleclick.net/gampad/ads?sz=640x480&iu=/124319096/external/single_ad_samples&ciu_szs=300x250&impl=s&gdfp_req=1&env=vp&output=vast&unviewed_position_start=1&cust_params=deployment%3Ddevsite%26sample_ct%3Dskippablelinear&correlator=';
 
         // Single VPAID 2.0 Linear
-        // var vastTag = 'https://pubads.g.doubleclick.net/gampad/ads?sz=640x480&iu=/124319096/external/single_ad_samples&ciu_szs=300x250&impl=s&gdfp_req=1&env=vp&output=vast&unviewed_position_start=1&cust_params=deployment%3Ddevsite%26sample_ct%3Dlinearvpaid2js&correlator='
+        // var vastTag = 'https://pubads.g.doubleclick.net/gampad/ads?sz=640x480&iu=/124319096/external/single_ad_samples&ciu_szs=300x250&impl=s&gdfp_req=1&env=vp&output=vast&unviewed_position_start=1&cust_params=deployment%3Ddevsite%26sample_ct%3Dlinearvpaid2js&correlator=';
 
         // Single VPAID 2.0 Non-Linear
-        // var vastTag = 'https://pubads.g.doubleclick.net/gampad/ads?sz=640x480&iu=/124319096/external/single_ad_samples&ciu_szs=300x250&impl=s&gdfp_req=1&env=vp&output=vast&unviewed_position_start=1&cust_params=deployment%3Ddevsite%26sample_ct%3Dnonlinearvpaid2js&correlator='
+        // var vastTag = 'https://pubads.g.doubleclick.net/gampad/ads?sz=640x480&iu=/124319096/external/single_ad_samples&ciu_szs=300x250&impl=s&gdfp_req=1&env=vp&output=vast&unviewed_position_start=1&cust_params=deployment%3Ddevsite%26sample_ct%3Dnonlinearvpaid2js&correlator=';
 
         // Single Non-linear Inline
-        // var vastTag = 'https://pubads.g.doubleclick.net/gampad/ads?sz=480x70&iu=/124319096/external/single_ad_samples&ciu_szs=300x250&impl=s&gdfp_req=1&env=vp&output=vast&unviewed_position_start=1&cust_params=deployment%3Ddevsite%26sample_ct%3Dnonlinear&correlator='
+        // var vastTag = 'https://pubads.g.doubleclick.net/gampad/ads?sz=480x70&iu=/124319096/external/single_ad_samples&ciu_szs=300x250&impl=s&gdfp_req=1&env=vp&output=vast&unviewed_position_start=1&cust_params=deployment%3Ddevsite%26sample_ct%3Dnonlinear&correlator=';
 
-        var player = new Clappr.Player({
-          parentId: ".player",
-          source: videoUrl,
-          disableKeyboardShortcuts: true,
-          disableVideoTagContextMenu: true,
-          autoSeekFromUrl: false,
-          width: '100%',
-          height: '100%',
-          autoPlay: false,
-          playback: {
-            playInline: true,
-          },
-          plugins: {
-            core: [ClapprGoogleImaHtml5PrerollPlugin],
-          },
-          googleImaHtml5PrerollPlugin: {
-            tag: vastTag,
-            // autostart: false,
+        var pluginConfig = function(tagUrl, autostart) {
+          return {
+            tag: tagUrl, // VAST tag URL (or false to disable plugin)
             vpaid: 1, // Default is 0 (DISABLED)
-            // nonLinearDuration: 10000, // Default is 5000 milliseconds
+            autostart: autostart,
+            // nonLinearDuration: 20000, // Default is 15000 milliseconds
             imaLoadTimeout: 3000, // Default is 6000 milliseconds
             events: {
               content_resume_requested: function() { console.log('content_resume_requested') },
@@ -79,22 +73,71 @@
               ad_error: function(e) { console.log('ad_error: ' + e.getError()) },
               error: function(e) { console.log('error', e) },
             }
+          };
+        };
+
+        var playerConfig = function(p, source, autoPlay) {
+          var po = p.options;
+          po.source = source;
+          po.autoPlay = autoPlay;
+          return po;
+        };
+
+        var resizePlayerDiv = function(w, h) {
+          var p = $('.player')[0];
+          p.style.width = w;
+          p.style.height = h;
+        };
+
+        var player = new Clappr.Player({
+          parentId: ".player",
+          source: SINTEL,
+          disableKeyboardShortcuts: true,
+          disableVideoTagContextMenu: true,
+          autoSeekFromUrl: false,
+          width: '100%',
+          height: '100%',
+          autoPlay: false,
+          playback: {
+            playInline: true,
+            recycleVideo: isMobile,
           },
+          plugins: {
+            core: [ClapprGoogleImaHtml5PrerollPlugin],
+          },
+          googleImaHtml5PrerollPlugin: pluginConfig(vastTag, !isMobile),
         })
 
-        window.resizePlayer = function() {
-          var p = $('.player')[0];
-          p.style.width = '1280px';
-          p.style.height = '720px';
-        };
-        window.resetPlayer = function() {
-          var p = $('.player')[0];
-          p.style.width = '';
-          p.style.height = '';
-        };
-      })()
+        $('.btn-resize').on('click', function() {
+          resizePlayerDiv('1280px', '720px');
+        });
+
+        $('.btn-reset').on('click', function() {
+          resizePlayerDiv('', '');
+        });
+
+        $('.btn-bunny').on('click', function() {
+          player.consent();
+          var o = playerConfig(player, BUNNY, false);
+          o.googleImaHtml5PrerollPlugin = pluginConfig(vastTag, true);
+          player.configure(o);
+        });
+
+        $('.btn-sintel').on('click', function() {
+          player.consent();
+          var o = playerConfig(player, SINTEL, false);
+          o.googleImaHtml5PrerollPlugin = pluginConfig(vastTag, true);
+          console.log('player options', player.options)
+          player.configure(o);
+        });
+
+        $('.btn-sintel-noad').on('click', function() {
+          player.consent();
+          var o = playerConfig(player, SINTEL, true);
+          o.googleImaHtml5PrerollPlugin = pluginConfig(false, true);
+          player.configure(o);
+        });
+      })();
     </script>
-    <button onclick="window.resizePlayer()">Resize player</button>
-    <button onclick="window.resetPlayer()">Reset player size</button>
   </body>
 </html>

--- a/src/ima-loader.js
+++ b/src/ima-loader.js
@@ -6,7 +6,7 @@
  * @param {number} The load timeout in milliseconds
  */
 export default function (cb, secure, timeout) {
-  let win = window, doc = document, el = 'script'
+  let win = window, doc = document, el = 'script', timer = null
 
   let onLoad = (r) => {
     win.clearTimeout(timer)
@@ -19,7 +19,6 @@ export default function (cb, secure, timeout) {
     return
   }
 
-  let timer = null
   let s = secure === true ? 'https:' : ''
   let first = doc.getElementsByTagName(el)[0]
   let script = doc.createElement(el)


### PR DESCRIPTION
It allow to load another preroll (or not) when loading another source with same player instance. (for example using `player.configure()` method).

* bump Clappr version support to 0.2.87 or greater
* load IMA SDK only if tag plugin option is filled (disable plugin if set to false)
* increase nonLinearDuration default value to 15000 (15 seconds)

BREAKING CHANGES:

* ad is not requested before user click overlay (or autostarted).
* a new AdDisplayContainer and AdLoader is created for each new loaded player source
